### PR TITLE
Remove stray console.log statements

### DIFF
--- a/components/CommentForm.js
+++ b/components/CommentForm.js
@@ -29,8 +29,7 @@ const CommentForm = ({ postId, parentId = 0 }) => {
 				author_email: email,
 				content,
 			});
-			console.log('Comment submitted response:', response);
-			console.log('Comment submitted:', response.data);
+
 			if( response.status === 201 ){
 				if( !userData || !userData.token ){
 					setAuthorName('');

--- a/pages/category/index.js
+++ b/pages/category/index.js
@@ -32,7 +32,7 @@ export default function Category() {
 		}
 	}
 
-	console.log('siteCategories', siteCategories);
+
 
 	return (
 		<div className='container max-w-screen-md mx-auto my-10 inline-block'>

--- a/pages/login.js
+++ b/pages/login.js
@@ -28,7 +28,7 @@ export default function LoginPage() {
 							// console.log('User is already logged in:', user);
 							setUser(user);
 						} else {
-							console.log('User is not logged in');
+
 						}
 					});
 				}

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -32,7 +32,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({params}) {
 
-  console.log('static params', params);
+  
   // console.log('static context', context);
   const { slug } = params;
   // console.log('params of static props', id);
@@ -103,7 +103,7 @@ const PostPage = ({ post, relatedPosts, categories, tags, comments }) => {
 
   const addReply = (parentId) => {
     // Set up your reply form logic here
-    console.log('Reply to comment ID:', parentId);
+    
     setParentId(parentId);
   };
 

--- a/pages/tag/index.js
+++ b/pages/tag/index.js
@@ -32,7 +32,7 @@ export default function Tag() {
 		}
 	}
 
-	console.log('siteTags', siteTags.length);
+
 
 	return (
 		<div className='container max-w-screen-md mx-auto my-10 inline-block'>


### PR DESCRIPTION
## Summary
- clean up debug `console.log` calls from login, post page, comment form, tag and category pages
- run lint to ensure no style issues

## Testing
- `SITE_DOMAIN=example.com npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68635197e30c8328a81fa3ee3e32ca9d