### PR TITLE
Remove leftover debugger in slug page

### DIFF
--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -23,7 +23,6 @@ export async function getStaticPaths() {
       id: post.id.toString()
     },
   }));
-  debugger;
   /**
    * Return the paths, and set fallback to false to return a 404 if the post doesn't exist
    */


### PR DESCRIPTION
## Summary
- remove stray `debugger` line from `getStaticPaths`

## Testing
- `npm run lint` *(fails: Invalid next.config.ts option)*

------
https://chatgpt.com/codex/tasks/task_e_686355fa68388328a4e01371e628d3c6